### PR TITLE
fix on StringSize for WPF & WPF sample compiles again

### DIFF
--- a/nuget/CrossGraphics.2010.nuspec
+++ b/nuget/CrossGraphics.2010.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <version>1.0.5</version>
+    <authors>Frank A. Krueger</authors>
+    <owners>Frank A. Krueger</owners>
+    <projectUrl>https://github.com/praeclarum/CrossGraphics</projectUrl>
+    <id>CrossGraphics-gregsn</id>
+    <title>CrossGraphics</title>
+	  <licenseUrl>https://github.com/praeclarum/sqlite-net/blob/master/license.md</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Cross-platform library for rendering vector graphics and writing graphics-rich apps. Supports iOS, OS X, Android, Windows Phone, Windows RT, WPF among a variety of file formats.</description>
+    <tags>graphics rendering vector draw svg wmf</tags>
+	  <summary>Cross-platform library for rendering vector graphics.</summary>
+	  <releaseNotes>
+      <![CDATA[
+      v1.0.5: Fixed bugs with WPF touch and mouse events
+      v1.0.4: Added framework: portable-sl4+wp71+windows8
+      v1.0.3: Added framework: windowsphone8
+      v1.0.2: Cleaned up the namespace
+		  v1.0.1: Initial Release
+		  ]]>
+	  </releaseNotes>
+  </metadata>
+  <files>
+    <file src="net40client\bin\Release\*.dll" target="lib\net40-client" />
+    <file src="net40client\bin\Release\*.pdb" target="lib\net40-client" />
+  </files>
+</package>

--- a/nuget/CrossGraphics.2010.nuspec
+++ b/nuget/CrossGraphics.2010.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>1.0.11</version>
+    <version>1.0.12</version>
     <authors>Frank A. Krueger</authors>
     <owners>gregsn</owners>
     <projectUrl>https://github.com/vvvv/CrossGraphics</projectUrl>
@@ -14,6 +14,7 @@
 	  <summary>Cross-platform library for rendering vector graphics.</summary>
 	  <releaseNotes>
       <![CDATA[
+	  v1.0.12: Fixed outline drawing of rectangles in Direct2D
 	  v1.0.11: Direct2D graphics exposes the render target in order for clients to change certain render settings
 	  v1.0.10: Fixed the SaveState and RestoreState methods in Direct2D
       v1.0.9: Fully implemented the DrawText and DrawArc methods in Direct2D

--- a/nuget/CrossGraphics.2010.nuspec
+++ b/nuget/CrossGraphics.2010.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>1.0.13</version>
+    <version>1.0.14</version>
     <authors>Frank A. Krueger</authors>
     <owners>gregsn</owners>
     <projectUrl>https://github.com/vvvv/CrossGraphics</projectUrl>
@@ -14,6 +14,7 @@
 	  <summary>Cross-platform library for rendering vector graphics.</summary>
 	  <releaseNotes>
       <![CDATA[
+	  v1.0.14: Added factory function for fonts
 	  v1.0.13: Added points to pixel and pixel to DIP helper methods
 	  v1.0.12: Fixed outline drawing of rectangles in Direct2D
 	  v1.0.11: Direct2D graphics exposes the render target in order for clients to change certain render settings

--- a/nuget/CrossGraphics.2010.nuspec
+++ b/nuget/CrossGraphics.2010.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <authors>Frank A. Krueger</authors>
     <owners>gregsn</owners>
     <projectUrl>https://github.com/vvvv/CrossGraphics</projectUrl>
@@ -14,6 +14,7 @@
 	  <summary>Cross-platform library for rendering vector graphics.</summary>
 	  <releaseNotes>
       <![CDATA[
+	  v1.0.13: Added points to pixel and pixel to DIP helper methods
 	  v1.0.12: Fixed outline drawing of rectangles in Direct2D
 	  v1.0.11: Direct2D graphics exposes the render target in order for clients to change certain render settings
 	  v1.0.10: Fixed the SaveState and RestoreState methods in Direct2D

--- a/nuget/CrossGraphics.2010.nuspec
+++ b/nuget/CrossGraphics.2010.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
     <authors>Frank A. Krueger</authors>
     <owners>gregsn</owners>
     <projectUrl>https://github.com/vvvv/CrossGraphics</projectUrl>
@@ -14,6 +14,7 @@
 	  <summary>Cross-platform library for rendering vector graphics.</summary>
 	  <releaseNotes>
       <![CDATA[
+      v1.0.9: Fully implemented the DrawText and DrawArc methods in Direct2D
       v1.0.8: Fixed memory leak in Direct2D and upgraded to SharpDX 2.6.3
       v1.0.7: Fixed rectangle drawing in Direct2D
       v1.0.6: Added Direct2DGraphics to nuget package

--- a/nuget/CrossGraphics.2010.nuspec
+++ b/nuget/CrossGraphics.2010.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <authors>Frank A. Krueger</authors>
     <owners>gregsn</owners>
     <projectUrl>https://github.com/vvvv/CrossGraphics</projectUrl>
@@ -14,6 +14,7 @@
 	  <summary>Cross-platform library for rendering vector graphics.</summary>
 	  <releaseNotes>
       <![CDATA[
+	  v1.0.11: Direct2D graphics exposes the render target in order for clients to change certain render settings
 	  v1.0.10: Fixed the SaveState and RestoreState methods in Direct2D
       v1.0.9: Fully implemented the DrawText and DrawArc methods in Direct2D
       v1.0.8: Fixed memory leak in Direct2D and upgraded to SharpDX 2.6.3

--- a/nuget/CrossGraphics.2010.nuspec
+++ b/nuget/CrossGraphics.2010.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     <authors>Frank A. Krueger</authors>
     <owners>gregsn</owners>
     <projectUrl>https://github.com/vvvv/CrossGraphics</projectUrl>
@@ -14,6 +14,7 @@
 	  <summary>Cross-platform library for rendering vector graphics.</summary>
 	  <releaseNotes>
       <![CDATA[
+	  v1.0.10: Fixed the SaveState and RestoreState methods in Direct2D
       v1.0.9: Fully implemented the DrawText and DrawArc methods in Direct2D
       v1.0.8: Fixed memory leak in Direct2D and upgraded to SharpDX 2.6.3
       v1.0.7: Fixed rectangle drawing in Direct2D

--- a/nuget/CrossGraphics.2010.nuspec
+++ b/nuget/CrossGraphics.2010.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>1.0.14</version>
+    <version>1.0.15-SharpDX3</version>
     <authors>Frank A. Krueger</authors>
     <owners>gregsn</owners>
     <projectUrl>https://github.com/vvvv/CrossGraphics</projectUrl>
@@ -11,9 +11,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Cross-platform library for rendering vector graphics and writing graphics-rich apps. Supports iOS, OS X, Android, Windows Phone, Windows RT, WPF among a variety of file formats.</description>
     <tags>graphics rendering vector draw svg wmf</tags>
-	  <summary>Cross-platform library for rendering vector graphics.</summary>
-	  <releaseNotes>
+	<summary>Cross-platform library for rendering vector graphics.</summary>
+	<releaseNotes>
       <![CDATA[
+	  v1.0.15: Updated SharpDX to 3.0.0-alpha01
 	  v1.0.14: Added factory function for fonts
 	  v1.0.13: Added points to pixel and pixel to DIP helper methods
 	  v1.0.12: Fixed outline drawing of rectangles in Direct2D
@@ -29,10 +30,15 @@
       v1.0.2: Cleaned up the namespace
 		  v1.0.1: Initial Release
 		  ]]>
-	  </releaseNotes>
+	</releaseNotes>
+	<dependencies>
+      <dependency id="SharpDX" version="3.0.0-alpha01" />
+      <dependency id="SharpDX.Mathematics" version="3.0.0-alpha01" />
+	  <dependency id="SharpDX.DXGI" version="3.0.0-alpha01" />
+	  <dependency id="SharpDX.Direct2D1" version="3.0.0-alpha01" />
+    </dependencies> 
   </metadata>
   <files>
-    <file src="net40client\bin\Release\*.dll" target="lib\net40-client" />
-    <file src="net40client\bin\Release\*.pdb" target="lib\net40-client" />
+    <file src="net40client\bin\Release\CrossGraphics.*" target="lib\net452" />
   </files>
 </package>

--- a/nuget/CrossGraphics.2010.nuspec
+++ b/nuget/CrossGraphics.2010.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <authors>Frank A. Krueger</authors>
     <owners>gregsn</owners>
     <projectUrl>https://github.com/vvvv/CrossGraphics</projectUrl>
@@ -14,6 +14,7 @@
 	  <summary>Cross-platform library for rendering vector graphics.</summary>
 	  <releaseNotes>
       <![CDATA[
+      v1.0.8: Fixed memory leak in Direct2D and upgraded to SharpDX 2.6.3
       v1.0.7: Fixed rectangle drawing in Direct2D
       v1.0.6: Added Direct2DGraphics to nuget package
       v1.0.5: Fixed bugs with WPF touch and mouse events

--- a/nuget/CrossGraphics.2010.nuspec
+++ b/nuget/CrossGraphics.2010.nuspec
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <authors>Frank A. Krueger</authors>
-    <owners>Frank A. Krueger</owners>
-    <projectUrl>https://github.com/praeclarum/CrossGraphics</projectUrl>
+    <owners>gregsn</owners>
+    <projectUrl>https://github.com/vvvv/CrossGraphics</projectUrl>
     <id>CrossGraphics-gregsn</id>
     <title>CrossGraphics</title>
 	  <licenseUrl>https://github.com/praeclarum/sqlite-net/blob/master/license.md</licenseUrl>
@@ -14,6 +14,7 @@
 	  <summary>Cross-platform library for rendering vector graphics.</summary>
 	  <releaseNotes>
       <![CDATA[
+      v1.0.6: Added Direct2DGraphics to nuget package
       v1.0.5: Fixed bugs with WPF touch and mouse events
       v1.0.4: Added framework: portable-sl4+wp71+windows8
       v1.0.3: Added framework: windowsphone8

--- a/nuget/CrossGraphics.2010.nuspec
+++ b/nuget/CrossGraphics.2010.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <authors>Frank A. Krueger</authors>
     <owners>gregsn</owners>
     <projectUrl>https://github.com/vvvv/CrossGraphics</projectUrl>
@@ -14,6 +14,7 @@
 	  <summary>Cross-platform library for rendering vector graphics.</summary>
 	  <releaseNotes>
       <![CDATA[
+      v1.0.7: Fixed rectangle drawing in Direct2D
       v1.0.6: Added Direct2DGraphics to nuget package
       v1.0.5: Fixed bugs with WPF touch and mouse events
       v1.0.4: Added framework: portable-sl4+wp71+windows8

--- a/nuget/CrossGraphics.2010.sln
+++ b/nuget/CrossGraphics.2010.sln
@@ -1,0 +1,78 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "netcore45", "netcore45\netcore45.csproj", "{FDD26A29-0993-46D9-B393-CA5357AE75D6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "net40client", "net40client\net40client.csproj", "{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "windowsphone8", "windowsphone8\windowsphone8.csproj", "{58E1541B-307D-4E9F-AB56-CB2A226DA34D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "portable", "portable\portable.csproj", "{F037C323-242D-40B1-A6BB-3FB4DD270C3F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|ARM = Debug|ARM
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|ARM = Release|ARM
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|ARM.ActiveCfg = Debug|ARM
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|ARM.Build.0 = Debug|ARM
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|x64.ActiveCfg = Debug|x64
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|x64.Build.0 = Debug|x64
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|x86.ActiveCfg = Debug|x86
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|x86.Build.0 = Debug|x86
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|ARM.ActiveCfg = Release|ARM
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|ARM.Build.0 = Release|ARM
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|x64.ActiveCfg = Release|x64
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|x64.Build.0 = Release|x64
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|x86.ActiveCfg = Release|x86
+		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|x86.Build.0 = Release|x86
+		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Release|x64.ActiveCfg = Release|Any CPU
+		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Release|x86.ActiveCfg = Release|Any CPU
+		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Debug|ARM.ActiveCfg = Debug|ARM
+		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Debug|ARM.Build.0 = Debug|ARM
+		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Debug|x86.ActiveCfg = Debug|x86
+		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Debug|x86.Build.0 = Debug|x86
+		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Release|ARM.ActiveCfg = Release|ARM
+		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Release|ARM.Build.0 = Release|ARM
+		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Release|x64.ActiveCfg = Release|Any CPU
+		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Release|x86.ActiveCfg = Release|x86
+		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Release|x86.Build.0 = Release|x86
+		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Release|x64.ActiveCfg = Release|Any CPU
+		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Release|x86.ActiveCfg = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/nuget/CrossGraphics.2010.sln
+++ b/nuget/CrossGraphics.2010.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "net40client", "net40client\net40client.csproj", "{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}"
 EndProject
 Global

--- a/nuget/CrossGraphics.2010.sln
+++ b/nuget/CrossGraphics.2010.sln
@@ -1,13 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "netcore45", "netcore45\netcore45.csproj", "{FDD26A29-0993-46D9-B393-CA5357AE75D6}"
-EndProject
+# Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "net40client", "net40client\net40client.csproj", "{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "windowsphone8", "windowsphone8\windowsphone8.csproj", "{58E1541B-307D-4E9F-AB56-CB2A226DA34D}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "portable", "portable\portable.csproj", "{F037C323-242D-40B1-A6BB-3FB4DD270C3F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,22 +15,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|ARM.ActiveCfg = Debug|ARM
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|ARM.Build.0 = Debug|ARM
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|x64.ActiveCfg = Debug|x64
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|x64.Build.0 = Debug|x64
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|x86.ActiveCfg = Debug|x86
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Debug|x86.Build.0 = Debug|x86
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|ARM.ActiveCfg = Release|ARM
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|ARM.Build.0 = Release|ARM
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|x64.ActiveCfg = Release|x64
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|x64.Build.0 = Release|x64
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|x86.ActiveCfg = Release|x86
-		{FDD26A29-0993-46D9-B393-CA5357AE75D6}.Release|x86.Build.0 = Release|x86
 		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -47,30 +25,6 @@ Global
 		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Release|ARM.ActiveCfg = Release|Any CPU
 		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Release|x64.ActiveCfg = Release|Any CPU
 		{F3B0DFB6-7DC1-469D-97AA-6575B550FE62}.Release|x86.ActiveCfg = Release|Any CPU
-		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Debug|ARM.ActiveCfg = Debug|ARM
-		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Debug|ARM.Build.0 = Debug|ARM
-		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Debug|x86.ActiveCfg = Debug|x86
-		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Debug|x86.Build.0 = Debug|x86
-		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Release|ARM.ActiveCfg = Release|ARM
-		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Release|ARM.Build.0 = Release|ARM
-		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Release|x64.ActiveCfg = Release|Any CPU
-		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Release|x86.ActiveCfg = Release|x86
-		{58E1541B-307D-4E9F-AB56-CB2A226DA34D}.Release|x86.Build.0 = Release|x86
-		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Debug|ARM.ActiveCfg = Debug|Any CPU
-		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Release|ARM.ActiveCfg = Release|Any CPU
-		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Release|x64.ActiveCfg = Release|Any CPU
-		{F037C323-242D-40B1-A6BB-3FB4DD270C3F}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/nuget/build.2010.bat
+++ b/nuget/build.2010.bat
@@ -1,0 +1,1 @@
+NuGet Pack CrossGraphics.2010.nuspec -o .\

--- a/nuget/net40client/app.config
+++ b/nuget/net40client/app.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="SharpDX" publicKeyToken="b4dcf0f35e5521f1" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SharpDX.DXGI" publicKeyToken="b4dcf0f35e5521f1" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/nuget/net40client/net40client.csproj
+++ b/nuget/net40client/net40client.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <NuGetPackageImportStamp>915e881e</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,14 +36,17 @@
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="SharpDX">
-      <HintPath>..\packages\SharpDX.2.5.0\lib\net40\SharpDX.dll</HintPath>
+    <Reference Include="SharpDX, Version=2.6.3.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(SharpDXPackageBinDir)\SharpDX.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.Direct2D1">
-      <HintPath>..\packages\SharpDX.Direct2D1.2.5.0\lib\net40\SharpDX.Direct2D1.dll</HintPath>
+    <Reference Include="SharpDX.Direct2D1, Version=2.6.3.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(SharpDXPackageBinDir)\SharpDX.Direct2D1.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.DXGI">
-      <HintPath>..\packages\SharpDX.DXGI.2.5.0\lib\net40\SharpDX.DXGI.dll</HintPath>
+    <Reference Include="SharpDX.DXGI, Version=2.6.3.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(SharpDXPackageBinDir)\SharpDX.DXGI.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -90,6 +94,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\SharpDX.2.6.3\build\SharpDX.targets" Condition="Exists('..\packages\SharpDX.2.6.3\build\SharpDX.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\SharpDX.2.6.3\build\SharpDX.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SharpDX.2.6.3\build\SharpDX.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/nuget/net40client/net40client.csproj
+++ b/nuget/net40client/net40client.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CrossGraphics</RootNamespace>
     <AssemblyName>CrossGraphics</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
-    <NuGetPackageImportStamp>915e881e</NuGetPackageImportStamp>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <NuGetPackageImportStamp>4e7c7f94</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -23,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,21 +34,25 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="SharpDX, Version=2.6.3.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+    <Reference Include="SharpDX, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(SharpDXPackageBinDir)\SharpDX.dll</HintPath>
+      <HintPath>..\packages\SharpDX.3.0.0-alpha01\lib\net45\SharpDX.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.Direct2D1, Version=2.6.3.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+    <Reference Include="SharpDX.Direct2D1, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(SharpDXPackageBinDir)\SharpDX.Direct2D1.dll</HintPath>
+      <HintPath>..\packages\SharpDX.Direct2D1.3.0.0-alpha01\lib\net45\SharpDX.Direct2D1.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.DXGI, Version=2.6.3.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+    <Reference Include="SharpDX.DXGI, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(SharpDXPackageBinDir)\SharpDX.DXGI.dll</HintPath>
+      <HintPath>..\packages\SharpDX.DXGI.3.0.0-alpha01\lib\net45\SharpDX.DXGI.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.Mathematics">
+      <HintPath>..\packages\SharpDX.Mathematics.3.0.0-alpha01\lib\net45\SharpDX.Mathematics.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -91,16 +97,10 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\SharpDX.2.6.3\build\SharpDX.targets" Condition="Exists('..\packages\SharpDX.2.6.3\build\SharpDX.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\SharpDX.2.6.3\build\SharpDX.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SharpDX.2.6.3\build\SharpDX.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/nuget/net40client/net40client.csproj
+++ b/nuget/net40client/net40client.csproj
@@ -39,20 +39,21 @@
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="SharpDX, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\SharpDX.3.0.0-alpha01\lib\net45\SharpDX.dll</HintPath>
+    <Reference Include="SharpDX, Version=3.0.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.3.0.1\lib\net45\SharpDX.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="SharpDX.Direct2D1, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\SharpDX.Direct2D1.3.0.0-alpha01\lib\net45\SharpDX.Direct2D1.dll</HintPath>
+    <Reference Include="SharpDX.Direct2D1, Version=3.0.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.Direct2D1.3.0.1\lib\net45\SharpDX.Direct2D1.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="SharpDX.DXGI, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\SharpDX.DXGI.3.0.0-alpha01\lib\net45\SharpDX.DXGI.dll</HintPath>
+    <Reference Include="SharpDX.DXGI, Version=3.0.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.DXGI.3.0.1\lib\net45\SharpDX.DXGI.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="SharpDX.Mathematics">
-      <HintPath>..\packages\SharpDX.Mathematics.3.0.0-alpha01\lib\net45\SharpDX.Mathematics.dll</HintPath>
+    <Reference Include="SharpDX.Mathematics, Version=3.0.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.Mathematics.3.0.1\lib\net45\SharpDX.Mathematics.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/nuget/net40client/net40client.csproj
+++ b/nuget/net40client/net40client.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,14 +30,25 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="SharpDX">
+      <HintPath>..\packages\SharpDX.2.5.0\lib\net40\SharpDX.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.Direct2D1">
+      <HintPath>..\packages\SharpDX.Direct2D1.2.5.0\lib\net40\SharpDX.Direct2D1.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.DXGI">
+      <HintPath>..\packages\SharpDX.DXGI.2.5.0\lib\net40\SharpDX.DXGI.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Presentation" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
@@ -48,6 +60,9 @@
     </Compile>
     <Compile Include="..\..\src\Canvas.cs">
       <Link>Canvas.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Direct2DGraphics.cs">
+      <Link>Direct2DGraphics.cs</Link>
     </Compile>
     <Compile Include="..\..\src\Graphics.cs">
       <Link>Graphics.cs</Link>
@@ -70,6 +85,9 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/nuget/net40client/packages.config
+++ b/nuget/net40client/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpDX" version="2.6.3" targetFramework="net40-Client" />
-  <package id="SharpDX.Direct2D1" version="2.6.3" targetFramework="net40-Client" />
-  <package id="SharpDX.DXGI" version="2.6.3" targetFramework="net40-Client" />
+  <package id="SharpDX" version="3.0.0-alpha01" targetFramework="net452" />
+  <package id="SharpDX.Direct2D1" version="3.0.0-alpha01" targetFramework="net452" />
+  <package id="SharpDX.DXGI" version="3.0.0-alpha01" targetFramework="net452" />
+  <package id="SharpDX.Mathematics" version="3.0.0-alpha01" targetFramework="net452" />
 </packages>

--- a/nuget/net40client/packages.config
+++ b/nuget/net40client/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpDX" version="3.0.0-alpha01" targetFramework="net452" />
-  <package id="SharpDX.Direct2D1" version="3.0.0-alpha01" targetFramework="net452" />
-  <package id="SharpDX.DXGI" version="3.0.0-alpha01" targetFramework="net452" />
-  <package id="SharpDX.Mathematics" version="3.0.0-alpha01" targetFramework="net452" />
+  <package id="SharpDX" version="3.0.1" targetFramework="net452" />
+  <package id="SharpDX.Direct2D1" version="3.0.1" targetFramework="net452" />
+  <package id="SharpDX.DXGI" version="3.0.1" targetFramework="net452" />
+  <package id="SharpDX.Mathematics" version="3.0.1" targetFramework="net452" />
 </packages>

--- a/nuget/net40client/packages.config
+++ b/nuget/net40client/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpDX" version="2.5.0" targetFramework="net40-Client" />
-  <package id="SharpDX.Direct2D1" version="2.5.0" targetFramework="net40-Client" />
-  <package id="SharpDX.DXGI" version="2.5.0" targetFramework="net40-Client" />
+  <package id="SharpDX" version="2.6.3" targetFramework="net40-Client" />
+  <package id="SharpDX.Direct2D1" version="2.6.3" targetFramework="net40-Client" />
+  <package id="SharpDX.DXGI" version="2.6.3" targetFramework="net40-Client" />
 </packages>

--- a/nuget/net40client/packages.config
+++ b/nuget/net40client/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="SharpDX" version="2.5.0" targetFramework="net40-Client" />
+  <package id="SharpDX.Direct2D1" version="2.5.0" targetFramework="net40-Client" />
+  <package id="SharpDX.DXGI" version="2.5.0" targetFramework="net40-Client" />
+</packages>

--- a/nuget/packages/repositories.config
+++ b/nuget/packages/repositories.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<repositories>
+  <repository path="..\net40client\packages.config" />
+</repositories>

--- a/samples/Clock/ClockWpf/ClockWpf.csproj
+++ b/samples/Clock/ClockWpf/ClockWpf.csproj
@@ -62,11 +62,11 @@
     <Compile Include="..\..\..\src\Graphics.cs">
       <Link>Graphics.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\src\SilverlightGraphics.cs">
-      <Link>SilverlightGraphics.cs</Link>
-    </Compile>
     <Compile Include="..\..\..\src\System.Drawing.cs">
       <Link>System.Drawing.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\src\XamlGraphics.cs">
+      <Link>XamlGraphics.cs</Link>
     </Compile>
     <Compile Include="..\Clock\Clock.cs">
       <Link>Clock.cs</Link>

--- a/samples/Clock/ClockWpf/MainWindow.xaml.cs
+++ b/samples/Clock/ClockWpf/MainWindow.xaml.cs
@@ -1,14 +1,14 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Threading;
-using CrossGraphics.SilverlightGraphics;
+using CrossGraphics;
 
 namespace ClockWpf
 {
 	public partial class MainWindow : Window
 	{
 		Clock.Clock _clock;
-		SilverlightGraphics _graphics;
+        XamlGraphics _graphics;
 
 		public MainWindow ()
 		{
@@ -18,7 +18,7 @@ namespace ClockWpf
 
 		private void Window_Loaded (object sender, RoutedEventArgs e)
 		{
-			_graphics = new SilverlightGraphics (LayoutRoot);
+			_graphics = new XamlGraphics (LayoutRoot);
 
 			var timer = new DispatcherTimer {
 				Interval = TimeSpan.FromSeconds (1),

--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -23,7 +23,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.14.*")]
-[assembly: AssemblyFileVersion("1.0.14")]
-[assembly: AssemblyInformationalVersion("1.0.14")]
+[assembly: AssemblyVersion("1.0.15.*")]
+[assembly: AssemblyFileVersion("1.0.15")]
+[assembly: AssemblyInformationalVersion("1.0.15")]
 //[assembly: ComVisible(false)]

--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -23,6 +23,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.5.*")]
-[assembly: AssemblyFileVersion("1.0.5")]
+[assembly: AssemblyVersion("1.0.14.*")]
+[assembly: AssemblyFileVersion("1.0.14")]
+[assembly: AssemblyInformationalVersion("1.0.14")]
 //[assembly: ComVisible(false)]

--- a/src/Direct2DGraphics.cs
+++ b/src/Direct2DGraphics.cs
@@ -22,126 +22,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
 using SharpDX.Direct2D1;
 using SharpDX;
 
 namespace CrossGraphics
 {
-	class WindowsDrawTimer
-	{
-		int _fps = 20;
-		readonly DispatcherTimer _drawTimer;
-
-		const double CpuUtilization = 0.25;
-		public int MinFps { get; set; }
-		public int MaxFps { get; set; }
-		static readonly TimeSpan ThrottleInterval = TimeSpan.FromSeconds (1.0);
-
-		double _drawTime;
-		int _drawCount;
-		DateTime _lastThrottleTime = DateTime.Now;
-
-		public bool Continuous { get; set; }
-
-		public WindowsDrawTimer ()
-		{
-			MinFps = 4;
-			MaxFps = 30;
-			Continuous = true;
-
-			_drawTimer = new DispatcherTimer ();
-			_drawTimer.Tick += DrawTick;
-		}
-
-		public void Start ()
-		{
-			_drawTimer.Interval = TimeSpan.FromSeconds (1.0 / _fps);
-
-			if (Continuous && !_drawTimer.IsEnabled) {
-				_drawTimer.Start ();
-			}
-		}
-
-		bool _paused = false;
-		public bool Paused
-		{
-			get
-			{
-				return _paused;
-			}
-			set
-			{
-				if (_paused != value) {
-					_paused = value;
-					_lastThrottleTime = DateTime.Now;
-				}
-			}
-		}
-
-		public void Stop ()
-		{
-			_drawTimer.Stop ();
-		}
-
-		public Func<bool> ShouldDrawFunc { get; set; }
-		public Func<double> DrawFunc { get; set; }
-
-		void DrawTick (object sender, object e)
-		{
-			//
-			// Decide if we should draw
-			//
-			if (Paused) {
-				_drawCount = 0;
-				_drawTime = 0;
-				return;
-			}
-
-			var sd = ShouldDrawFunc;
-			if (sd != null) {
-				if (!sd ()) {
-					return;
-				}
-			}
-
-			//
-			// Draw
-			//
-			var d = DrawFunc;
-			if (d != null) {
-				var dt = d ();
-				_drawTime += dt;
-				_drawCount++;
-			}
-
-			//
-			// Throttle
-			//
-			if (_drawCount > 2 && (DateTime.Now - _lastThrottleTime) >= ThrottleInterval) {
-
-				_lastThrottleTime = DateTime.Now;
-
-				var maxfps = 1.0 / (_drawTime / _drawCount);
-				_drawTime = 0;
-				_drawCount = 0;
-
-				var fps = ClampUpdateFreq ((int)(maxfps * CpuUtilization));
-
-				if (Math.Abs (fps - _fps) > 1) {
-					_fps = fps;
-					Start ();
-				}
-			}
-		}
-
-		int ClampUpdateFreq (int fps)
-		{
-			return Math.Min (MaxFps, Math.Max (MinFps, fps));
-		}
-	}
-
 	public class Direct2DGraphics : IGraphics
 	{
 		const int MaxFontSize = 120;
@@ -180,20 +65,30 @@ namespace CrossGraphics
 			dc = DisposeLater (new RenderTarget (
 				d2dFactory,
 				surface,
-				new RenderTargetProperties (
-					RenderTargetType.Default,
-					new SharpDX.Direct2D1.PixelFormat (SharpDX.DXGI.Format.B8G8R8A8_UNorm, AlphaMode.Premultiplied),
-					d2dFactory.DesktopDpi.Width, d2dFactory.DesktopDpi.Height,
-					RenderTargetUsage.None,
-					FeatureLevel.Level_DEFAULT)));
+                new RenderTargetProperties(new PixelFormat(SharpDX.DXGI.Format.Unknown, AlphaMode.Premultiplied)))
+            );
 
 			Initialize ();
 		}
 
+        public Direct2DGraphics(IntPtr handle, int width, int height)
+            : this()
+        {
+            //surface = DisposeLater(SharpDX.DXGI.Surface.FromSwapChain(swapChain, 0));
+            dc = DisposeLater(new WindowRenderTarget(
+                d2dFactory,
+                new RenderTargetProperties(new PixelFormat(SharpDX.DXGI.Format.Unknown, AlphaMode.Premultiplied)),
+                new HwndRenderTargetProperties() { Hwnd = handle, PixelSize = new Size2(width, height), PresentOptions = PresentOptions.None }
+                )
+            );
+
+            Initialize();
+        }
+
 		public Direct2DGraphics (int width, int height)
 			: this ()
 		{
-			var wicFactory = new SharpDX.WIC.ImagingFactory2 ();
+			var wicFactory = new SharpDX.WIC.ImagingFactory();
 			bitmap = DisposeLater (new SharpDX.WIC.Bitmap (
 				wicFactory,
 				width, height,
@@ -357,14 +252,14 @@ namespace CrossGraphics
 		{
 			var rx = width / 2;
 			var ry = height / 2;
-			dc.FillEllipse (new Ellipse (new DrawingPointF (x + rx, y + ry), rx, ry), lastColor.GetBrush (dc));
+			dc.FillEllipse (new Ellipse (new Vector2 (x + rx, y + ry), rx, ry), lastColor.GetBrush (dc));
 		}
 
 		public void DrawOval (float x, float y, float width, float height, float w)
 		{
 			var rx = width / 2;
 			var ry = height / 2;
-			dc.DrawEllipse (new Ellipse (new DrawingPointF (x + rx, y + ry), rx, ry), lastColor.GetBrush (dc), w);
+            dc.DrawEllipse(new Ellipse(new Vector2(x + rx, y + ry), rx, ry), lastColor.GetBrush(dc), w);
 		}
 
 		public void BeginLines (bool rounded)
@@ -373,7 +268,7 @@ namespace CrossGraphics
 
 		public void DrawLine (float sx, float sy, float ex, float ey, float w)
 		{
-			dc.DrawLine (new DrawingPointF (sx, sy), new DrawingPointF (ex, ey), lastColor.GetBrush (dc), w, strokeStyle);
+            dc.DrawLine(new Vector2(sx, sy), new Vector2(ex, ey), lastColor.GetBrush(dc), w, strokeStyle);
 		}
 
 		public void EndLines ()
@@ -547,8 +442,8 @@ namespace CrossGraphics
 			if (g == null) {
 				var pg = new PathGeometry (factory);
 				using (var gs = pg.Open ()) {
-					gs.BeginFigure (new DrawingPointF (poly.Points[0].X, poly.Points[0].Y), FigureBegin.Filled);
-					gs.AddLines (poly.Points.Select (p => new DrawingPointF (p.X, p.Y)).ToArray ());
+                    gs.BeginFigure(new Vector2(poly.Points[0].X, poly.Points[0].Y), FigureBegin.Filled);
+					gs.AddLines (poly.Points.Select (p => new Vector2 (p.X, p.Y)).ToArray ());
 					gs.EndFigure (FigureEnd.Closed);
 					gs.Close ();
 				}
@@ -589,190 +484,6 @@ namespace CrossGraphics
 			}
 
 			return ci.Brush;
-		}
-	}
-
-	public class Direct2DCanvas : SwapChainBackgroundPanel, ICanvas
-	{
-		SharpDX.DXGI.SwapChain1 swapChain;
-		Direct2DGraphics g;
-		WindowsDrawTimer _drawTimer;
-
-		CanvasContent content;
-		public CanvasContent Content
-		{
-			get
-			{
-				return content;
-			}
-			set
-			{
-				if (content != value) {
-					if (content != null) {
-						content.NeedsDisplay -= OnNeedsDisplay;
-					}
-					content = value;
-					if (content != null) {
-						content.NeedsDisplay += OnNeedsDisplay;
-					}
-				}
-			}
-		}
-
-		public Direct2DCanvas ()
-		{
-			int width = 1024;
-			int height = 1024;
-
-			SharpDX.Direct3D11.Device defaultDevice = new SharpDX.Direct3D11.Device (
-				SharpDX.Direct3D.DriverType.Hardware,
-				SharpDX.Direct3D11.DeviceCreationFlags.BgraSupport);
-
-			// Query the default device for the supported device and context interfaces.
-			var device = defaultDevice.QueryInterface<SharpDX.Direct3D11.Device1> ();
-
-			// Query for the adapter and more advanced DXGI objects.
-			SharpDX.DXGI.Device2 dxgiDevice2 = device.QueryInterface<SharpDX.DXGI.Device2> ();
-			SharpDX.DXGI.Adapter dxgiAdapter = dxgiDevice2.Adapter;
-			SharpDX.DXGI.Factory2 dxgiFactory2 = dxgiAdapter.GetParent<SharpDX.DXGI.Factory2> ();
-
-			var swapChainDescription = new SharpDX.DXGI.SwapChainDescription1 {
-				Width = width,
-				Height = height,
-				Format = SharpDX.DXGI.Format.B8G8R8A8_UNorm,
-				Stereo = false,
-				Usage = SharpDX.DXGI.Usage.RenderTargetOutput,
-				BufferCount = 2,
-				Scaling = SharpDX.DXGI.Scaling.Stretch,
-				SwapEffect = SharpDX.DXGI.SwapEffect.FlipSequential,
-				Flags = SharpDX.DXGI.SwapChainFlags.None,
-			};
-			swapChainDescription.SampleDescription.Count = 1;
-			swapChainDescription.SampleDescription.Quality = 0;
-
-			swapChain = dxgiFactory2.CreateSwapChainForComposition (dxgiDevice2, ref swapChainDescription, null);
-			swapChain.BackgroundColor = new Color4 (1, 0, 0, 0);
-
-			var native = SharpDX.ComObject.QueryInterface<SharpDX.DXGI.ISwapChainBackgroundPanelNative> (this);
-			native.SwapChain = swapChain;
-
-			g = new Direct2DGraphics (swapChain);
-
-			_drawTimer = new WindowsDrawTimer {
-				Continuous = true,
-				ShouldDrawFunc = () =>
-					Content != null && ActualWidth > 0 && ActualHeight > 0,
-				DrawFunc = Draw,
-			};
-
-			Unloaded += HandleUnloaded;
-			Loaded += HandleLoaded;
-			LayoutUpdated += HandleLayoutUpdated;
-		}
-
-		double lastUpdateWidth = -1, lastUpdateHeight = -1;
-
-		void HandleLayoutUpdated (object sender, object e)
-		{
-			if (Content != null && (Math.Abs (lastUpdateWidth - ActualWidth) > 0.5 || Math.Abs (lastUpdateHeight - ActualHeight) > 0.5)) {
-				lastUpdateWidth = ActualWidth;
-				lastUpdateHeight = ActualHeight;
-
-				// TODO: Resize the SwapChain
-
-#if NETFX_CORE
-#pragma warning disable 4014
-				Dispatcher.RunAsync (Windows.UI.Core.CoreDispatcherPriority.Normal, delegate {
-					Content.SetNeedsDisplay ();
-				});
-#pragma warning restore 4014
-#endif
-			}
-		}
-
-		void HandleLoaded (object sender, RoutedEventArgs e)
-		{
-			//Debug.WriteLine("LOADED {0}", Delegate);
-			//TouchEnabled = true;
-			if (_drawTimer.Continuous) {
-				Start ();
-			}
-		}
-
-		void HandleUnloaded (object sender, RoutedEventArgs e)
-		{
-			//Debug.WriteLine("UNLOADED {0}", Delegate);
-			//TouchEnabled = false;
-			Stop ();
-		}
-
-		void OnNeedsDisplay (object sender, EventArgs e)
-		{
-			Draw ();
-		}
-
-		public void Start ()
-		{
-			_drawTimer.Start ();
-		}
-
-		public void Stop ()
-		{
-			_drawTimer.Stop ();
-		}
-
-		public Transform2D ContentTransform
-		{
-			get
-			{
-				return g.Transform;
-			}
-			set
-			{
-				g.Transform = value;
-				SetNeedsDisplay ();
-			}
-		}
-
-		void SetNeedsDisplay ()
-		{
-			Draw ();
-		}
-
-		double Draw ()
-		{
-			var del = Content;
-			if (del == null) return 0;
-
-			var startT = DateTime.Now;
-
-			g.BeginDrawing ();
-			g.BeginEntity (del);
-
-			//
-			// Draw
-			//
-			var fr = new System.Drawing.RectangleF (0, 0, (float)ActualWidth, (float)ActualHeight);
-			//if (_ppi != NativePointsPerInch) {
-			//	fr.Width /= _ppi / (float)NativePointsPerInch;
-			//	fr.Height /= _ppi / (float)NativePointsPerInch;
-			//}
-			del.Frame = fr;
-			try {
-				Console.WriteLine (g.Transform);
-				//g.Transform = transform;
-				g.Clear (Colors.Red);
-				del.Draw (g);
-			}
-			catch (Exception) {
-			}
-
-			g.EndDrawing ();
-
-			swapChain.Present (1, SharpDX.DXGI.PresentFlags.None);
-
-			var endT = DateTime.Now;
-			return (endT - startT).TotalSeconds;
 		}
 	}
 }

--- a/src/Direct2DGraphics.cs
+++ b/src/Direct2DGraphics.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using SharpDX.Direct2D1;
 using SharpDX;
 using DW = SharpDX.DirectWrite;
+using SharpDX.Mathematics.Interop;
 
 namespace CrossGraphics
 {
@@ -544,7 +545,7 @@ namespace CrossGraphics
 				var pg = new PathGeometry (factory);
 				using (var gs = pg.Open ()) {
                     gs.BeginFigure(new Vector2(poly.Points[0].X, poly.Points[0].Y), FigureBegin.Filled);
-					gs.AddLines (poly.Points.Select (p => new Vector2 (p.X, p.Y)).ToArray ());
+					gs.AddLines (poly.Points.Select(p => (RawVector2)new Vector2(p.X, p.Y)).ToArray ());
 					gs.EndFigure (FigureEnd.Closed);
 					gs.Close ();
 				}

--- a/src/Direct2DGraphics.cs
+++ b/src/Direct2DGraphics.cs
@@ -223,7 +223,7 @@ namespace CrossGraphics
 		public void FillRoundedRect (float x, float y, float width, float height, float radius)
 		{
 			dc.FillRoundedRectangle (new RoundedRectangle {
-				Rect = new RectangleF (x, y, x + width, y + height),
+				Rect = new RectangleF (x, y, width, height),
 				RadiusX = radius,
 				RadiusY = radius,
 			}, lastColor.GetBrush (dc));
@@ -232,7 +232,7 @@ namespace CrossGraphics
 		public void DrawRoundedRect (float x, float y, float width, float height, float radius, float w)
 		{
 			dc.DrawRoundedRectangle (new RoundedRectangle {
-				Rect = new RectangleF (x, y, x + width, y + height),
+				Rect = new RectangleF (x, y, width, height),
 				RadiusX = radius,
 				RadiusY = radius,
 			}, lastColor.GetBrush (dc), w);
@@ -240,12 +240,12 @@ namespace CrossGraphics
 
 		public void FillRect (float x, float y, float width, float height)
 		{
-			dc.FillRectangle (new RectangleF (x, y, x + width, y + height), lastColor.GetBrush (dc));
+			dc.FillRectangle (new RectangleF (x, y, width, height), lastColor.GetBrush (dc));
 		}
 
 		public void DrawRect (float x, float y, float width, float height, float w)
 		{
-			dc.DrawRectangle (new RectangleF (x, y, x + width, y + height), lastColor.GetBrush (dc), w);
+			dc.DrawRectangle (new RectangleF (x, y, width, height), lastColor.GetBrush (dc), w);
 		}
 
 		public void FillOval (float x, float y, float width, float height)
@@ -292,7 +292,7 @@ namespace CrossGraphics
 			dc.DrawText (
 				s,
 				textFormat,
-				new RectangleF (x, yy, x + 1000, yy + 1000),
+				new RectangleF (x, yy, 1000, 1000),
 				lastColor.GetBrush (dc));
 		}
 
@@ -303,7 +303,7 @@ namespace CrossGraphics
 			dc.DrawText (
 				s,
 				textFormat,
-				new RectangleF (x, yy, x + width, yy + height),
+				new RectangleF (x, yy, width, height),
 				lastColor.GetBrush (dc));
 		}
 

--- a/src/Direct2DGraphics.cs
+++ b/src/Direct2DGraphics.cs
@@ -113,9 +113,6 @@ namespace CrossGraphics
 			}));
 
 			states = new Stack<State> ();
-			states.Push (new State {
-				Transform = Matrix3x2.Identity,
-			});
 
             lastBrush = new SolidColorBrush(dc, Color4.Black);
 
@@ -399,12 +396,10 @@ namespace CrossGraphics
 
 		public void SaveState ()
 		{
-			var s = states.Peek ();
 			var n = new State {
-				Transform = s.Transform,
+				Transform = dc.Transform,
 			};
 			states.Push (n);
-			dc.Transform = n.Transform;
 		}
 
 		public void SetClippingRect (float x, float y, float width, float height)
@@ -450,11 +445,8 @@ namespace CrossGraphics
 
 		public void RestoreState ()
 		{
-			if (states.Count > 1) {
-				states.Pop ();
-				var s = states.Peek ();
-				dc.Transform = s.Transform;
-			}
+			var s = states.Pop();
+			dc.Transform = s.Transform;
 		}
 
 		public IImage ImageFromFile (string filename)

--- a/src/Direct2DGraphics.cs
+++ b/src/Direct2DGraphics.cs
@@ -248,7 +248,7 @@ namespace CrossGraphics
 		public void DrawRoundedRect (float x, float y, float width, float height, float radius, float w)
 		{
 			dc.DrawRoundedRectangle (new RoundedRectangle {
-				Rect = new RectangleF (x, y, width, height),
+                Rect = new RectangleF(x + w / 2, y + w / 2, width, height),
 				RadiusX = radius,
 				RadiusY = radius,
             }, lastBrush, w);
@@ -261,7 +261,7 @@ namespace CrossGraphics
 
 		public void DrawRect (float x, float y, float width, float height, float w)
 		{
-            dc.DrawRectangle(new RectangleF(x, y, width, height), lastBrush, w);
+            dc.DrawRectangle(new RectangleF(x + w / 2, y + w / 2, width, height), lastBrush, w);
 		}
 
 		public void FillOval (float x, float y, float width, float height)

--- a/src/Direct2DGraphics.cs
+++ b/src/Direct2DGraphics.cs
@@ -222,14 +222,18 @@ namespace CrossGraphics
 
 		public void FillPolygon (Polygon poly)
 		{
-			var g = poly.GetGeometry (d2dFactory);
-			dc.FillGeometry (g, lastBrush);
+            using (var g = poly.GetGeometry(d2dFactory))
+            {
+                dc.FillGeometry(g, lastBrush);
+            }
 		}
 
 		public void DrawPolygon (Polygon poly, float w)
 		{
-			var g = poly.GetGeometry (d2dFactory);
-            dc.DrawGeometry(g, lastBrush, w);
+            using (var g = poly.GetGeometry(d2dFactory))
+            {
+                dc.DrawGeometry(g, lastBrush, w);
+            }
 		}
 
 		public void FillRoundedRect (float x, float y, float width, float height, float radius)

--- a/src/Direct2DGraphics.cs
+++ b/src/Direct2DGraphics.cs
@@ -117,8 +117,6 @@ namespace CrossGraphics
             lastBrush = new SolidColorBrush(dc, Color4.Black);
 
 			SetFont (Font.SystemFontOfSize (16));
-
-            dc.TextAntialiasMode = TextAntialiasMode.Cleartype;
 		}
 
 		~Direct2DGraphics ()
@@ -131,6 +129,11 @@ namespace CrossGraphics
 			Dispose (true);
 			GC.SuppressFinalize (this);
 		}
+
+        public RenderTarget RenderTarget
+        {
+            get { return this.dc; }
+        }
 
 		List<IDisposable> toDispose;
 

--- a/src/Graphics.cs
+++ b/src/Graphics.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 
 namespace CrossGraphics
 {
@@ -199,69 +200,46 @@ namespace CrossGraphics
 			Options = options;
 			Size = size;
 		}
-		
-		static Font[] _boldSystemFonts = new Font[0];
-		static Font[] _systemFonts = new Font[0];
-		static Font[] _userFixedPitchFonts = new Font[0];
-		static Font[] _boldUserFixedPitchFonts = new Font[0];
 
-		public static Font BoldSystemFontOfSize (int size) {
-			if (size <= 0)
-				return BoldSystemFontOfSize (1);
-			if (size >= _boldSystemFonts.Length) {
-				return new Font ("SystemFont", FontOptions.Bold, size);
-			}
-			else {
-				var f = _boldSystemFonts[size];
-				if (f == null) {
-					f = new Font ("SystemFont", FontOptions.Bold, size);
-					_boldSystemFonts[size] = f;
-				}
-				return f;
-			}
+        static Dictionary<string, List<Font>> _fonts = new Dictionary<string, List<Font>>();
+
+        public static Font Get(string name, FontOptions options, int size)
+        {
+            List<Font> fonts;
+            if (!_fonts.TryGetValue(name, out fonts))
+            {
+                fonts = new List<Font>(1);
+                _fonts.Add(name, fonts);
+            }
+            var font = fonts.FirstOrDefault(f => f.FontFamily == name && f.Options == options && f.Size == size);
+            if (font == null)
+            {
+                font = new Font(name, options, size);
+                fonts.Add(font);
+            }
+            return font;
+        }
+
+		public static Font BoldSystemFontOfSize(int size) 
+        {
+            return Get("SystemFont", FontOptions.Bold, size);
 		}
-		public static Font SystemFontOfSize (int size) {
-			if (size >= _systemFonts.Length) {
-				return new Font ("SystemFont", FontOptions.None, size);
-			}
-			else {
-				var f = _systemFonts[size];
-				if (f == null) {
-					f = new Font ("SystemFont", FontOptions.None, size);
-					_systemFonts[size] = f;
-				}
-				return f;
-			}
+		public static Font SystemFontOfSize(int size) 
+        {
+            return Get("SystemFont", FontOptions.None, size);
 		}
-		public static Font UserFixedPitchFontOfSize (int size) {
-			if (size >= _userFixedPitchFonts.Length) {
-				return new Font ("Monospace", FontOptions.None, size);
-			}
-			else {
-				var f = _userFixedPitchFonts[size];
-				if (f == null) {
-					f = new Font ("Monospace", FontOptions.None, size);
-					_userFixedPitchFonts[size] = f;
-				}
-				return f;
-			}
+		public static Font UserFixedPitchFontOfSize(int size)
+        {
+            return Get("Monospace", FontOptions.Bold, size);
 		}
-		public static Font BoldUserFixedPitchFontOfSize (int size) {
-			if (size >= _boldUserFixedPitchFonts.Length) {
-				return new Font ("Monospace", FontOptions.Bold, size);
-			}
-			else {
-				var f = _boldUserFixedPitchFonts[size];
-				if (f == null) {
-					f = new Font ("Monospace", FontOptions.Bold, size);
-					_boldUserFixedPitchFonts[size] = f;
-				}
-				return f;
-			}
+		public static Font BoldUserFixedPitchFontOfSize(int size) 
+        {
+            return Get("Monospace", FontOptions.None, size);
 		}
 		
-		public static Font FromName (string name, int size) {
-			return new Font (name, FontOptions.None, size);
+		public static Font FromName(string name, int size) 
+        {
+            return Get(name, FontOptions.None, size);
 		}
 
 		public override string ToString()

--- a/src/XamlGraphics.cs
+++ b/src/XamlGraphics.cs
@@ -65,6 +65,7 @@ namespace CrossGraphics
 		EntityShapes _eshape = null;
 
 		Canvas _canvas;
+        TextBlock _txtMeasure;
 
 		class State
 		{
@@ -80,6 +81,11 @@ namespace CrossGraphics
 		{
 			if (canvas == null) throw new ArgumentNullException ("canvas");
 			_canvas = canvas;
+
+            _txtMeasure = new TextBlock();
+            _txtMeasure.Visibility = Visibility.Hidden;
+            _canvas.Children.Add(_txtMeasure);
+
 			_states.Push(new State());
 		}
 
@@ -268,7 +274,7 @@ namespace CrossGraphics
 			var f = _eshape.CurrentFont;
 			var fm = f.Tag as XamlFontMetrics;
 			if (fm == null) {
-				fm = new XamlFontMetrics (f);
+                fm = new XamlFontMetrics(_txtMeasure, f);
 				f.Tag = fm;
 			}
 			return fm;
@@ -298,13 +304,16 @@ namespace CrossGraphics
 	{
 		float[] _widths;
 		int _height = 10;
+        TextBlock _txtMeasure;
 		static float DefaultWidth = 9.5f;
 
 		public static readonly NativeFontFamily SystemFont = new NativeFontFamily ("Global User Interface");
 		public static readonly NativeFontFamily Monospace = new NativeFontFamily ("Courier New");
 
-		public XamlFontMetrics (Font f)
+		public XamlFontMetrics (TextBlock txtMeasure, Font f)
 		{
+            _txtMeasure = txtMeasure;
+
 			var ff = SystemFont;
 			if (f.FontFamily == "Monospace") {
 				ff = Monospace;
@@ -332,15 +341,16 @@ namespace CrossGraphics
 			}
 		}
 
-		static System.Drawing.SizeF StringSize (string text, int fontSize, NativeFontFamily fontFamily, bool bold)
+		System.Drawing.SizeF StringSize (string text, int fontSize, NativeFontFamily fontFamily, bool bold)
 		{
-			TextBlock txtMeasure = new TextBlock();
-			txtMeasure.FontFamily = fontFamily;
-			txtMeasure.FontSize = fontSize;
-			txtMeasure.FontWeight = bold ? FontWeights.Bold : FontWeights.Normal;
-			txtMeasure.Text = text;
-			txtMeasure.Measure (new Size (1, 1));
-			return new System.Drawing.SizeF((float)txtMeasure.ActualWidth, (float)txtMeasure.ActualHeight);
+            _txtMeasure.Visibility = Visibility.Hidden;
+			_txtMeasure.FontFamily = fontFamily;
+			_txtMeasure.FontSize = fontSize;
+			_txtMeasure.FontWeight = bold ? FontWeights.Bold : FontWeights.Normal;
+			_txtMeasure.Text = text;
+            _txtMeasure.UpdateLayout();
+			//txtMeasure.Measure (new Size (1, 1));
+			return new System.Drawing.SizeF((float)_txtMeasure.ActualWidth, (float)_txtMeasure.ActualHeight);
 		}
 
 		public int StringWidth(string str, int startIndex, int length)


### PR DESCRIPTION
Hi Frank!

I just fixed IFontMetrics.StringWidth() for WPF.
I don't know how you got that working on your side, but maybe Silverligth was just another story.
In WPF it is necessary to have that TextBox - the one that is misused to just retrieve the text width - to have that TextBox somehow rooted within a canvas (or maybe somewhere else also possible). 

So now we would just create one TextBox per canvas, put that in the canvas we get from the user, hide it, and use it for all text meassurements for that XamlGraphics...

Hope you like it. (Whitespaces in VisualStudio are fine) Sorry for that!

Thanks for this project! It is fun!

See you later,
Sebastian
